### PR TITLE
Java8 Time API replace with joda

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,7 +384,7 @@ CREATE TABLE REVINFO (
 * Spring中的验证：Spring如何支持域对象验证。Spring自己的Validator接口，以及重点关注JSR-349（bean验证）支持   
 
 ### 类型转换   
-`注册的ConversionServiceFactoryBean的Bean Name必须是conversionService，否则会ConversionNotSupportedException`
+`注册的ConversionServiceFactoryBean的Bean Name必须是conversionService，否则会抛出ConversionNotSupportedException`
     
     
 

--- a/chapter10/converter/src/main/java/com/isaac/ch10/Singer.java
+++ b/chapter10/converter/src/main/java/com/isaac/ch10/Singer.java
@@ -1,21 +1,19 @@
 package com.isaac.ch10;
 
 import lombok.Data;
-import org.joda.time.DateTime;
 
 import java.net.URL;
-import java.text.SimpleDateFormat;
+import java.time.LocalDate;
 
 @Data
 public class Singer {
     private String firstName;
     private String lastName;
-    private DateTime birthDate;
+    private LocalDate birthDate;
     private URL personalSite;
 
     public String toString() {
-        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
         return String.format("{First name: %s, Last name: %s, Birthday: %s, Site: %s}",
-                firstName, lastName, sdf.format(birthDate.toDate()), personalSite);
+                firstName, lastName, birthDate, personalSite);
     }
 }

--- a/chapter10/converter/src/main/java/com/isaac/ch10/StringToDateTimeConverter.java
+++ b/chapter10/converter/src/main/java/com/isaac/ch10/StringToDateTimeConverter.java
@@ -2,19 +2,18 @@ package com.isaac.ch10;
 
 import lombok.Getter;
 import lombok.Setter;
-import org.joda.time.DateTime;
-import org.joda.time.format.DateTimeFormat;
-import org.joda.time.format.DateTimeFormatter;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.stereotype.Component;
 
 import javax.annotation.PostConstruct;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 
 /**
  * 自定义转换器：将String格式的日期转换为Singer类的birthDate属性。
  */
 @Component
-public class StringToDateTimeConverter implements Converter<String, DateTime> {
+public class StringToDateTimeConverter implements Converter<String, LocalDate> {
     private static final String DEFAULT_DATE_PATTERN = "yyyy-MM-dd";
     private DateTimeFormatter dateFormatter;
     @Getter @Setter
@@ -22,11 +21,11 @@ public class StringToDateTimeConverter implements Converter<String, DateTime> {
 
     @PostConstruct
     public void init() {
-        this.dateFormatter = DateTimeFormat.forPattern(datePattern);
+        this.dateFormatter = DateTimeFormatter.ofPattern(datePattern);
     }
 
     @Override
-    public DateTime convert(String source) {
-        return dateFormatter.parseDateTime(source);
+    public LocalDate convert(String source) {
+        return LocalDate.parse(source,dateFormatter);
     }
 }

--- a/chapter10/converter/src/main/java/com/isaac/ch10/config/AppConfig.java
+++ b/chapter10/converter/src/main/java/com/isaac/ch10/config/AppConfig.java
@@ -1,8 +1,6 @@
 package com.isaac.ch10.config;
 
 import com.isaac.ch10.Singer;
-import com.isaac.ch10.StringToDateTimeConverter;
-import org.joda.time.DateTime;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
@@ -12,6 +10,7 @@ import org.springframework.context.support.ConversionServiceFactoryBean;
 import org.springframework.core.convert.converter.Converter;
 
 import java.net.URL;
+import java.time.LocalDate;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -26,7 +25,7 @@ public class AppConfig {
     public Singer taylor(@Value("${countrySinger.firstName}") String firstName,
                          @Value("${countrySinger.lastName}") String lastName,
                          @Value("${countrySinger.personalSite}") URL personalSite,
-                         @Value("${countrySinger.birthDate}") DateTime birthDate) {
+                         @Value("${countrySinger.birthDate}") LocalDate birthDate) {
         Singer singer = new Singer();
         singer.setFirstName(firstName);
         singer.setLastName(lastName);


### PR DESCRIPTION
now you can using java8 Time API.You can get info :
```Note that from Java SE 8 onwards, users are asked to migrate to java.time (JSR-310) - a core part of the JDK which replaces this project.```
from [joda](https://www.joda.org/joda-time/)